### PR TITLE
Fix assert message in alignedAllocate

### DIFF
--- a/src/tcmallocd/allocator.d
+++ b/src/tcmallocd/allocator.d
@@ -180,7 +180,7 @@ struct TCAlignedMallocator
             return null;
 
         else if (code == EINVAL)
-            assert (0, "AlignedMallocator.alignment is not a power of two multiple of (void*).sizeof, according to posix_memalign!");
+            assert (0, "Required alignment is not a power of two multiple of (void*).sizeof, according to posix_memalign!");
 
         else if (code != 0)
             assert (0, "posix_memalign returned an unknown code!");


### PR DESCRIPTION
alignedAllocate is a public method, and the passed alignment doesn't
need to be `AlignedMallocator.alignment`, so the assert message is
reworded accordingly.